### PR TITLE
feat(config/seo): update site configuration and enhance SEO metadata

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import icon from "astro-icon";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://astro-pico.netlify.app",
+  site: "https://tkhwang.github.io",
   integrations: [react(), icon(), mdx(), sitemap()],
   image: {
     domains: ["astro.build"],

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,6 @@
+export const SITE_TITLE = "Where Code Meets Design";
+export const SITE_SHORT_TITLE = "WCMD";
+export const SITE_DESCRIPTION =
+  "코드와 디자인이 만나는 지점에서 더 나은 소프트웨어를 만들기 위한 경험과 통찰을 기록하는 개발 블로그.";
+export const SITE_URL = "https://tkhwang.github.io";
+export const SITE_LOCALE = "ko_KR";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,12 +1,46 @@
 ---
 import Footer from "@components/Footer.astro";
 import { ViewTransitions } from "astro:transitions";
+import {
+  SITE_DESCRIPTION,
+  SITE_LOCALE,
+  SITE_TITLE,
+  SITE_URL,
+} from "../config/site";
 
 interface Props {
   pageTitle: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogType?: string;
+  ogImage?: string;
+  canonical?: string;
 }
 
-const { pageTitle } = Astro.props;
+const {
+  pageTitle,
+  description = SITE_DESCRIPTION,
+  ogTitle = pageTitle,
+  ogDescription = description,
+  ogType = "website",
+  ogImage,
+  canonical,
+} = Astro.props;
+
+const currentUrl = Astro.url;
+const siteOrigin = Astro.site?.origin ?? SITE_URL;
+let canonicalPath: string | undefined;
+if (typeof canonical === "string") {
+  canonicalPath = canonical;
+} else if (currentUrl) {
+  canonicalPath = currentUrl.pathname + currentUrl.search;
+}
+const canonicalUrl =
+  siteOrigin && canonicalPath
+    ? new URL(canonicalPath, siteOrigin).toString()
+    : undefined;
+const ogUrl = canonicalUrl ?? currentUrl?.toString();
 ---
 
 <html lang="en">
@@ -24,6 +58,18 @@ const { pageTitle } = Astro.props;
       href="https://cdn.jsdelivr.net/npm/theme-toggles@4.10.1/css/classic.min.css"
     /> -->
     <link rel="sitemap" href="/sitemap-index.xml" />
+    {canonicalUrl ? <link rel="canonical" href={canonicalUrl} /> : null}
+    <meta name="description" content={description} />
+    <meta property="og:site_name" content={SITE_TITLE} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
+    <meta property="og:type" content={ogType} />
+    {ogUrl ? <meta property="og:url" content={ogUrl} /> : null}
+    {SITE_LOCALE ? <meta property="og:locale" content={SITE_LOCALE} /> : null}
+    {ogImage ? <meta property="og:image" content={ogImage} /> : null}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={ogTitle} />
+    <meta name="twitter:description" content={ogDescription} />
     <title>{pageTitle}</title>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2236137669543501" crossorigin="anonymous"></script>
     <ViewTransitions />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,7 +43,7 @@ const canonicalUrl =
 const ogUrl = canonicalUrl ?? currentUrl?.toString();
 ---
 
-<html lang="en">
+<html lang={SITE_LOCALE.split('_')[0]}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
@@ -66,8 +66,8 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
     <meta property="og:type" content={ogType} />
     {ogUrl ? <meta property="og:url" content={ogUrl} /> : null}
     {SITE_LOCALE ? <meta property="og:locale" content={SITE_LOCALE} /> : null}
-    {ogImage ? <meta property="og:image" content={ogImage} /> : null}
-    <meta name="twitter:card" content="summary" />
+    {ogImage ? <meta property="og:image" content={new URL(ogImage, siteOrigin).toString()} /> : null}
+    <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
     <meta name="twitter:title" content={ogTitle} />
     <meta name="twitter:description" content={ogDescription} />
     <title>{pageTitle}</title>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -20,7 +20,6 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
 <BaseLayout
   pageTitle={frontmatter.title}
   description={frontmatter.description}
-  ogDescription={frontmatter.description}
   ogType="article"
 >
   <header>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -17,7 +17,12 @@ const formattedPubDate = Number.isNaN(pubDate.valueOf())
 const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
 ---
 
-<BaseLayout pageTitle={frontmatter.title}>
+<BaseLayout
+  pageTitle={frontmatter.title}
+  description={frontmatter.description}
+  ogDescription={frontmatter.description}
+  ogType="article"
+>
   <header>
     <NavWrapper />
   </header>

--- a/src/layouts/MdxProjectLayout.astro
+++ b/src/layouts/MdxProjectLayout.astro
@@ -18,7 +18,6 @@ const formattedPubDate = Number.isNaN(processedDate.valueOf())
 <BaseLayout
   pageTitle={frontmatter.title}
   description={frontmatter.description}
-  ogDescription={frontmatter.description}
   ogType="article"
 >
   <header>

--- a/src/layouts/MdxProjectLayout.astro
+++ b/src/layouts/MdxProjectLayout.astro
@@ -15,7 +15,12 @@ const formattedPubDate = Number.isNaN(processedDate.valueOf())
     });
 ---
 
-<BaseLayout pageTitle={frontmatter.title}>
+<BaseLayout
+  pageTitle={frontmatter.title}
+  description={frontmatter.description}
+  ogDescription={frontmatter.description}
+  ogType="article"
+>
   <header>
     <NavWrapper />
   </header>


### PR DESCRIPTION
Changed the site URL in the Astro configuration to point to the new GitHub Pages site. Added a new site configuration file to define site title, description, and locale. Enhanced the BaseLayout and MarkdownPostLayout to include Open Graph and Twitter metadata for improved SEO and social sharing capabilities.