### PR TITLE
style: update styling

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "pnpm install"
+  ]
+}

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,0 @@
-{
-  "setup-worktree": [
-    "pnpm install"
-  ]
-}

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -7,8 +7,7 @@ interface Props {
   tags?: string[];
 }
 
-const { url, title, pubDate, description, tags = [] } = Astro.props;
-const normalizedTags = Array.isArray(tags) ? tags : [];
+const { url, title, pubDate, description, tags: normalizedTags = [] } = Astro.props;
 ---
 
 <li class="post-item">

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -60,7 +60,7 @@ const { url, title, pubDate, description, tags: normalizedTags = [] } = Astro.pr
 
   .post-description {
     margin: 0 0 0.35rem;
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   .post-date {

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -4,21 +4,36 @@ interface Props {
   title: string;
   pubDate: Date;
   description: string;
+  tags?: string[];
 }
 
-const { url, title, pubDate, description } = Astro.props;
+const { url, title, pubDate, description, tags = [] } = Astro.props;
+const normalizedTags = Array.isArray(tags) ? tags : [];
 ---
 
 <li class="post-item">
   <a href={url} class="post-title">{title}</a>
-  <p class="post-description"><i>{description}</i></p>
-  <small class="post-date">
-    {pubDate.toLocaleDateString("ko-KR", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    })}
-  </small>
+  <p class="post-description">{description}</p>
+  <div class="post-meta">
+    <small class="post-date">
+      {pubDate.toLocaleDateString("ko-KR", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      })}
+    </small>
+    {normalizedTags.length > 0 ? (
+      <div class="post-tags">
+        {
+          normalizedTags.map((tag) => (
+            <a href={`/tags/${encodeURIComponent(tag)}/`} class="tag-chip">
+              {tag}
+            </a>
+          ))
+        }
+      </div>
+    ) : null}
+  </div>
 </li>
 
 <style>
@@ -46,10 +61,44 @@ const { url, title, pubDate, description } = Astro.props;
 
   .post-description {
     margin: 0 0 0.35rem;
+    color: #9ca3af;
   }
 
   .post-date {
-    display: block;
     margin: 0;
+    font-size: 0.95rem;
+    color: var(--pico-muted-color);
+  }
+
+  .post-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.35rem;
+  }
+
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background-color: #e0edff;
+    color: #1d4ed8;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .tag-chip:hover,
+  .tag-chip:focus {
+    background-color: #c7dbff;
   }
 </style>

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -88,8 +88,8 @@ const { url, title, pubDate, description, tags: normalizedTags = [] } = Astro.pr
     align-items: center;
     padding: 0.2rem 0.65rem;
     border-radius: 999px;
-    background-color: #e0edff;
-    color: #1d4ed8;
+    background-color: var(--color-tag-bg);
+    color: var(--color-tag-text);
     font-size: 0.85rem;
     font-weight: 600;
     text-decoration: none;
@@ -98,6 +98,6 @@ const { url, title, pubDate, description, tags: normalizedTags = [] } = Astro.pr
 
   .tag-chip:hover,
   .tag-chip:focus {
-    background-color: #c7dbff;
+    background-color: var(--color-tag-bg-hover);
   }
 </style>

--- a/src/components/Featured.astro
+++ b/src/components/Featured.astro
@@ -21,7 +21,7 @@ const featuredPosts = (await getCollection("posts"))
           title={post.data.title}
           pubDate={post.data.pubDate}
           description={post.data.description}
-          tags={Array.isArray(post.data.tags) ? post.data.tags : []}
+          tags={post.data.tags}
         />
     ))
   }

--- a/src/components/Featured.astro
+++ b/src/components/Featured.astro
@@ -16,12 +16,13 @@ const featuredPosts = (await getCollection("posts"))
 <ul>
   {
     featuredPosts.map((post) => (
-      <BlogPost
-        url={`/posts/${post.slug}/`}
-        title={post.data.title}
-        pubDate={post.data.pubDate}
-        description={post.data.description}
-      />
+        <BlogPost
+          url={`/posts/${post.slug}/`}
+          title={post.data.title}
+          pubDate={post.data.pubDate}
+          description={post.data.description}
+          tags={Array.isArray(post.data.tags) ? post.data.tags : []}
+        />
     ))
   }
 </ul>

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -19,6 +19,7 @@ const orderedPosts = allPosts.sort(
           title={post.data.title}
           pubDate={post.data.pubDate}
           description={post.data.description}
+          tags={Array.isArray(post.data.tags) ? post.data.tags : []}
         />
       ))
   }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -92,9 +92,14 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
 
 <style is:global>
   :root {
+    --color-text-muted: #9ca3af;
     --color-tag-bg: #e0edff;
     --color-tag-bg-hover: #c7dbff;
     --color-tag-text: #1d4ed8;
+    --color-tag-alt-bg: #e3f2fd;
+    --color-tag-alt-text: #1976d2;
+    --color-tag-alt-hover-bg: #bbdefb;
+    --color-tag-alt-hover-text: #1565c0;
   }
 
   .ibm-plex-sans-kr-regular {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -96,4 +96,55 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
     font-weight: 400;
     font-style: normal;
   }
+
+  /* Constrain content width similar to eugeneyan.com */
+  .container {
+    max-width: 850px;
+  }
+
+  /* Code block styling - wider than regular content */
+  .container pre,
+  .container pre.astro-code,
+  main pre,
+  main pre.astro-code {
+    max-width: 1000px !important;
+    width: 1000px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    overflow-x: auto !important;
+    border-radius: 0.5rem;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  /* Shiki generated code blocks */
+  .astro-code {
+    padding: 1rem;
+  }
+
+  /* Mobile responsive */
+  @media (max-width: 1250px) {
+    .container pre,
+    .container pre.astro-code,
+    main pre,
+    main pre.astro-code {
+      max-width: calc(100vw - 2rem) !important;
+      width: calc(100vw - 2rem) !important;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  @media (max-width: 850px) {
+    .container pre,
+    .container pre.astro-code,
+    main pre,
+    main pre.astro-code {
+      left: 0;
+      transform: none;
+      margin-left: 1rem !important;
+      margin-right: 1rem !important;
+    }
+  }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -91,6 +91,12 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
 </html>
 
 <style is:global>
+  :root {
+    --color-tag-bg: #e0edff;
+    --color-tag-bg-hover: #c7dbff;
+    --color-tag-text: #1d4ed8;
+  }
+
   .ibm-plex-sans-kr-regular {
     font-family: "IBM Plex Sans KR", sans-serif;
     font-weight: 400;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -120,15 +120,13 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
   }
 
   /* Code block styling - wider than regular content */
-  .container pre,
-  .container pre.astro-code,
-  main pre,
-  main pre.astro-code {
-    max-width: 1000px !important;
-    width: 1000px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-    overflow-x: auto !important;
+  body.ibm-plex-sans-kr-regular
+    :is(.container pre, .container pre.astro-code, main pre, main pre.astro-code) {
+    max-width: 1000px;
+    width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+    overflow-x: auto;
     border-radius: 0.5rem;
     position: relative;
     left: 50%;
@@ -142,26 +140,22 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
 
   /* Mobile responsive */
   @media (max-width: 1250px) {
-    .container pre,
-    .container pre.astro-code,
-    main pre,
-    main pre.astro-code {
-      max-width: calc(100vw - 2rem) !important;
-      width: calc(100vw - 2rem) !important;
+    body.ibm-plex-sans-kr-regular
+      :is(.container pre, .container pre.astro-code, main pre, main pre.astro-code) {
+      max-width: calc(100vw - 2rem);
+      width: calc(100vw - 2rem);
       left: 50%;
       transform: translateX(-50%);
     }
   }
 
   @media (max-width: 850px) {
-    .container pre,
-    .container pre.astro-code,
-    main pre,
-    main pre.astro-code {
+    body.ibm-plex-sans-kr-regular
+      :is(.container pre, .container pre.astro-code, main pre, main pre.astro-code) {
       left: 0;
       transform: none;
-      margin-left: 1rem !important;
-      margin-right: 1rem !important;
+      margin-left: 1rem;
+      margin-right: 1rem;
     }
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -102,6 +102,23 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
     max-width: 850px;
   }
 
+  /* Header 상하 여백 줄이기 */
+  header {
+    margin-bottom: 0;
+    padding-top: 1rem;
+    padding-bottom: 0.5rem;
+  }
+
+  nav {
+    margin-bottom: 0;
+  }
+
+  /* header 다음 hr 여백 줄이기 */
+  header + hr {
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
   /* Code block styling - wider than regular content */
   .container pre,
   .container pre.astro-code,

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -42,9 +42,7 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
       <section>
         <hgroup>
           <h1>{frontmatter.title}</h1>
-          <p>
-            <em>{frontmatter.description}</em>
-          </p>
+          <p class="post-description">{frontmatter.description}</p>
           {tags.length > 0 ? (
             <p class="post-tags">
               [ {tags.map((tag: string, index: number) => (
@@ -80,6 +78,12 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
   }
 
   hgroup p {
+    margin-bottom: 0.75rem;
+  }
+
+  .post-description {
+    color: #9ca3af;
+    font-weight: 500;
     margin-bottom: 0.75rem;
   }
 

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -42,20 +42,23 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
       <section>
         <hgroup>
           <h1>{frontmatter.title}</h1>
-          <p>{formattedPubDate}</p>
-          <!-- <p>Written by: <a href="/about/">{frontmatter.author}</a></p> -->
           <p>
             <em>{frontmatter.description}</em>
           </p>
           {tags.length > 0 ? (
-            <div class="post-tags">
-              {tags.map((tag: string) => (
-                <a class="secondary" href={`/tags/${encodeURIComponent(tag)}/`}>
-                  #{tag}
-                </a>
-              ))}
-            </div>
+            <p class="post-tags">
+              [ {tags.map((tag: string, index: number) => (
+                <>
+                  <a href={`/tags/${encodeURIComponent(tag)}/`}>
+                    {tag}
+                  </a>
+                  {index < tags.length - 1 ? ', ' : ''}
+                </>
+              ))} ]
+            </p>
           ) : null}
+          <p>{formattedPubDate}</p>
+          <!-- <p>Written by: <a href="/about/">{frontmatter.author}</a></p> -->
         </hgroup>
       </section>
       <hr />
@@ -81,13 +84,25 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
   }
 
   .post-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
     margin: 0;
+    color: var(--pico-muted-color);
   }
 
   .post-tags a {
-    margin: 0;
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    background-color: #e3f2fd;
+    color: #1976d2;
+    text-decoration: none;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+  }
+
+  .post-tags a:hover {
+    background-color: #bbdefb;
+    color: #1565c0;
+    transform: translateY(-1px);
   }
 </style>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -82,7 +82,7 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
   }
 
   .post-description {
-    color: #9ca3af;
+    color: var(--color-text-muted);
     font-weight: 500;
     margin-bottom: 0.75rem;
   }
@@ -95,18 +95,19 @@ const tags = Array.isArray(frontmatter.tags) ? frontmatter.tags : [];
   .post-tags a {
     display: inline-block;
     padding: 0.25rem 0.75rem;
-    background-color: #e3f2fd;
-    color: #1976d2;
+    background-color: var(--color-tag-alt-bg);
+    color: var(--color-tag-alt-text);
     text-decoration: none;
     border-radius: 0.25rem;
     font-size: 0.875rem;
     font-weight: 500;
-    transition: all 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease,
+      transform 0.2s ease;
   }
 
   .post-tags a:hover {
-    background-color: #bbdefb;
-    color: #1565c0;
+    background-color: var(--color-tag-alt-hover-bg);
+    color: var(--color-tag-alt-hover-text);
     transform: translateY(-1px);
   }
 </style>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -32,6 +32,7 @@ const pageTitle: string = "Blog";
               title={post.data.title}
               pubDate={post.data.pubDate}
               description={post.data.description}
+              tags={Array.isArray(post.data.tags) ? post.data.tags : []}
             />
           ))
         }

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -32,7 +32,7 @@ const pageTitle: string = "Blog";
               title={post.data.title}
               pubDate={post.data.pubDate}
               description={post.data.description}
-              tags={Array.isArray(post.data.tags) ? post.data.tags : []}
+              tags={post.data.tags}
             />
           ))
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -75,7 +75,7 @@ const pageTitle: string = "Where Code Meets Design";
 
 <style>
   .intro-muted {
-    color: #9ca3af;
+    color: var(--color-text-muted);
     font-weight: 500;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,10 +22,12 @@ const pageTitle: string = "Where Code Meets Design";
         <h1>{pageTitle}</h1>
       </hgroup>
       <p>
-        코드와 디자인이 만나는 지점에서, <br />
-        더 나은 소프트웨어를 만들기 위한 고민과 통찰을 기록합니다. <br />
+        코드와 디자인이 만나는 지점에서, 더 나은 소프트웨어를 만들기 위한 고민과 통찰을 기록합니다. <br />
         기술과 디자인, 두 세계의 경계에서 얻은 개발 이야기.
       </p>
+        <span class="intro-muted">
+          Clean | Hexagonal architecture, CQRS, Event Sourcing, Design pattern, ...
+        </span>
     </section>
     <section>
       <hr /> 
@@ -70,3 +72,10 @@ const pageTitle: string = "Where Code Meets Design";
     </section> -->
   </main>
 </BaseLayout>
+
+<style>
+  .intro-muted {
+    color: #9ca3af;
+    font-weight: 500;
+  }
+</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -85,6 +85,7 @@ const sortedTagCloud = tagCloud
               title={post.data.title}
               pubDate={post.data.pubDate}
               description={post.data.description}
+              tags={Array.isArray(post.data.tags) ? post.data.tags : []}
             />
           ))
         }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -121,8 +121,8 @@ const sortedTagCloud = tagCloud
     align-items: center;
     padding: 0.3rem 1rem;
     border-radius: 999px;
-    background-color: #e0edff;
-    color: #1d4ed8;
+    background-color: var(--color-tag-bg);
+    color: var(--color-tag-text);
     font-weight: 700;
     font-size: clamp(1.4rem, 3.5vw, 1.9rem);
   }
@@ -147,7 +147,7 @@ const sortedTagCloud = tagCloud
     padding: 0.3rem 0.9rem;
     border-radius: 999px;
     background-color: #eef2ff;
-    color: #1d4ed8;
+    color: var(--color-tag-text);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 600;
@@ -160,7 +160,7 @@ const sortedTagCloud = tagCloud
   }
 
   .tag-chip.active {
-    background-color: #1d4ed8;
+    background-color: var(--color-tag-text);
     color: #fff;
   }
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 
   const tagCountMap = new Map<string, number>();
   orderedPosts.forEach((post) => {
-    const tags = Array.isArray(post.data.tags) ? post.data.tags : [];
+    const tags = post.data.tags;
     tags.forEach((tag) => {
       tagCountMap.set(tag, (tagCountMap.get(tag) ?? 0) + 1);
     });
@@ -85,7 +85,7 @@ const sortedTagCloud = tagCloud
               title={post.data.title}
               pubDate={post.data.pubDate}
               description={post.data.description}
-              tags={Array.isArray(post.data.tags) ? post.data.tags : []}
+              tags={post.data.tags}
             />
           ))
         }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -26,9 +26,10 @@ export async function getStaticPaths() {
   }));
 
   return uniqueTags.map((tag) => {
-    const filteredPosts = orderedPosts.filter((post) =>
-      post.data.tags.includes(tag),
-    );
+    const filteredPosts = orderedPosts.filter((post) => {
+      const tags = Array.isArray(post.data.tags) ? post.data.tags : [];
+      return tags.includes(tag);
+    });
     return {
       params: { tag: encodeURIComponent(tag) },
       props: { posts: filteredPosts, tagLabel: tag, tagCloud },

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -11,9 +11,19 @@ export async function getStaticPaths() {
       new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf(),
   );
 
-  const uniqueTags = [
-    ...new Set(orderedPosts.map((post) => post.data.tags).flat()),
-  ];
+  const tagCountMap = new Map<string, number>();
+  orderedPosts.forEach((post) => {
+    const tags = Array.isArray(post.data.tags) ? post.data.tags : [];
+    tags.forEach((tag) => {
+      tagCountMap.set(tag, (tagCountMap.get(tag) ?? 0) + 1);
+    });
+  });
+
+  const uniqueTags = [...tagCountMap.keys()];
+  const tagCloud = uniqueTags.map((tag) => ({
+    label: tag,
+    count: tagCountMap.get(tag) ?? 0,
+  }));
 
   return uniqueTags.map((tag) => {
     const filteredPosts = orderedPosts.filter((post) =>
@@ -21,15 +31,18 @@ export async function getStaticPaths() {
     );
     return {
       params: { tag: encodeURIComponent(tag) },
-      props: { posts: filteredPosts, tagLabel: tag },
+      props: { posts: filteredPosts, tagLabel: tag, tagCloud },
     };
   });
 }
 
 const { tag: tagSlug } = Astro.params;
-const { posts, tagLabel } = Astro.props;
+const { posts, tagLabel, tagCloud = [] } = Astro.props;
 const currentTag = tagLabel ?? decodeURIComponent(tagSlug);
 const pageTitle = `Tag: ${currentTag}`;
+const sortedTagCloud = tagCloud
+  .slice()
+  .sort((a, b) => a.label.localeCompare(b.label, "ko", { sensitivity: "base" }));
 ---
 
 <BaseLayout pageTitle={pageTitle}>
@@ -38,12 +51,31 @@ const pageTitle = `Tag: ${currentTag}`;
   </header>
   <hr />
   <main class="container">
-    <section>
-      <hgroup>
-        <h1>{pageTitle}</h1>
-        <p>{posts.length} post{posts.length === 1 ? "" : "s"}</p>
-      </hgroup>
+    <section class="tag-hero-section">
+      <h2 class="tag-hero">
+        <span class="tag-label">Tag:</span>
+        <span class="tag-badge">{currentTag}</span>
+        <span class="tag-count">({posts.length})</span>
+      </h2>
     </section>
+    {sortedTagCloud.length > 0 ? (
+      <section class="tag-cloud">
+        <a href="/tags/" class="tag-chip">
+          all
+        </a>
+        {
+          sortedTagCloud.map((tag) => (
+            <a
+              href={`/tags/${encodeURIComponent(tag.label)}/`}
+              class={`tag-chip${tag.label === currentTag ? " active" : ""}`}
+            >
+              {tag.label}
+              <span class="tag-chip-count">{tag.count}</span>
+            </a>
+          ))
+        }
+      </section>
+    ) : null}
     <section>
       <ul>
         {
@@ -60,3 +92,80 @@ const pageTitle = `Tag: ${currentTag}`;
     </section>
   </main>
 </BaseLayout>
+
+<style>
+  .tag-hero-section {
+    margin-bottom: 1.75rem;
+  }
+
+  .tag-hero {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    font-size: clamp(1.4rem, 3.5vw, 2rem);
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  .tag-label {
+    color: #6b7280;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  .tag-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3rem 1rem;
+    border-radius: 999px;
+    background-color: #e0edff;
+    color: #1d4ed8;
+    font-weight: 700;
+    font-size: clamp(1.4rem, 3.5vw, 1.9rem);
+  }
+
+  .tag-count {
+    color: #374151;
+    font-weight: 600;
+    font-size: clamp(1.2rem, 3vw, 1.6rem);
+  }
+
+  .tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    background-color: #eef2ff;
+    color: #1d4ed8;
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 600;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .tag-chip:hover,
+  .tag-chip:focus {
+    background-color: #dbe7ff;
+  }
+
+  .tag-chip.active {
+    background-color: #1d4ed8;
+    color: #fff;
+  }
+
+  .tag-chip-count {
+    font-size: 0.85rem;
+    color: inherit;
+    opacity: 0.8;
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds tag chips across posts and a tag cloud with counts, while refining post metadata layout, global styles, and page intro text.
> 
> - **UI/Posts**:
>   - `BlogPost.astro`: add optional `tags` prop, render tags as linked chips in `post-meta`; restyle description/date.
>   - Pass `tags` to `BlogPost` in `Featured.astro`, `LatestPosts.astro`, `pages/blog.astro`, and `pages/tags/[tag].astro`.
> - **Tags Page** (`pages/tags/[tag].astro`):
>   - Build tag counts in `getStaticPaths`; provide `tagCloud` prop.
>   - Add tag hero with current tag and post count; render tag cloud with active state and counts.
>   - Defensive handling for missing tags; add comprehensive styles for chips/hero.
> - **Layouts/Styling**:
>   - `BaseLayout.astro`: introduce CSS variables for muted text/tag colors; constrain `.container`; adjust header spacing; widen and tweak code block styling with responsive rules.
>   - `MarkdownPostLayout.astro`: restyle description; change tag rendering to inline list with styled links; move date below tags.
> - **Home** (`pages/index.astro`):
>   - Tweak intro copy and add muted tagline with style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de1a50423c74693278f4b2463cecb5691eee43be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->