### PR TITLE
style: simplify blog post list to minimal title+date layout

### DIFF
--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -3,103 +3,53 @@ interface Props {
   url: string;
   title: string;
   pubDate: Date;
-  description: string;
+  description?: string;
   tags?: string[];
 }
 
-const { url, title, pubDate, description, tags: normalizedTags = [] } = Astro.props;
+const { url, title, pubDate } = Astro.props;
+
+const yyyy = pubDate.getFullYear();
+const mm = String(pubDate.getMonth() + 1).padStart(2, '0');
+const dd = String(pubDate.getDate()).padStart(2, '0');
+const dateStr = `${yyyy}-${mm}-${dd}`;
 ---
 
 <li class="post-item">
-  <div class="post-meta">
-    <small class="post-date">
-      {pubDate.toLocaleDateString("ko-KR", {
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      })}
-    </small>
-    {normalizedTags.length > 0 ? (
-      <div class="post-tags">
-        {
-          normalizedTags.map((tag) => (
-            <a href={`/tags/${encodeURIComponent(tag)}/`} class="tag-chip">
-              {tag}
-            </a>
-          ))
-        }
-      </div>
-    ) : null}
-  </div>
-  <a href={url} class="post-title">{title}</a>
-  <p class="post-description">{description}</p>
-
+  <a href={url} class="post-link">
+    <span class="post-title">{title}</span>
+    <span class="post-date">{dateStr}</span>
+  </a>
 </li>
 
 <style>
   .post-item {
-    margin: 0 0 1.5rem;
+    padding: 0.35rem 0;
+    list-style: none;
   }
 
-  .post-item:last-child {
-    margin-bottom: 0;
-  }
-
-  .post-title,
-  .post-title:visited {
+  .post-link {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
     color: inherit;
     text-decoration: none;
-    font-weight: 700;
-    display: inline-block;
-    margin-bottom: 0.35rem;
   }
 
-  .post-title:hover,
-  .post-title:focus {
+  .post-link:hover .post-title,
+  .post-link:focus .post-title {
     text-decoration: underline;
   }
 
-  .post-description {
-    margin: 0 0 0.35rem;
-    color: var(--color-text-muted);
+  .post-title {
+    font-weight: 700;
   }
 
   .post-date {
-    margin: 0;
-    font-size: 0.95rem;
+    flex-shrink: 0;
+    font-size: 0.875rem;
     color: var(--pico-muted-color);
-  }
-
-  .post-meta {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    margin-top: 0.35rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .post-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-  }
-
-  .tag-chip {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.2rem 0.65rem;
-    border-radius: 999px;
-    background-color: var(--color-tag-bg);
-    color: var(--color-tag-text);
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-decoration: none;
-    transition: background-color 0.2s ease, color 0.2s ease;
-  }
-
-  .tag-chip:hover,
-  .tag-chip:focus {
-    background-color: var(--color-tag-bg-hover);
+    font-variant-numeric: tabular-nums;
   }
 </style>

--- a/src/components/Featured.astro
+++ b/src/components/Featured.astro
@@ -13,7 +13,7 @@ const featuredPosts = (await getCollection("posts"))
   .slice(0, 5);
 ---
 
-<ul>
+<ul class="post-list">
   {
     featuredPosts.map((post) => (
         <BlogPost

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -9,7 +9,7 @@ const orderedPosts = allPosts.sort(
 );
 ---
 
-<ul>
+<ul class="post-list">
   {
     orderedPosts
       .slice(0, 20)

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -234,6 +234,13 @@ const ogUrl = canonicalUrl ?? currentUrl?.toString();
     letter-spacing: 0.01em;
   }
 
+  /* Post list reset */
+  .post-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+
   /* KaTeX display math left alignment */
   .katex-display {
     text-align: left !important;

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -24,7 +24,7 @@ const pageTitle: string = "Blog";
       </hgroup>
     </section>
     <section>
-      <ul>
+      <ul class="post-list">
         {
           orderedPosts.map((post) => (
             <BlogPost

--- a/src/pages/featured.astro
+++ b/src/pages/featured.astro
@@ -28,7 +28,7 @@ const pageTitle: string = "추천 글";
     {
       featuredPosts.length > 0 ? (
         <section>
-          <ul>
+          <ul class="post-list">
             {
               featuredPosts.map((post) => (
                 <BlogPost

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import BaseLayout from "@layouts/BaseLayout.astro";
 import NavWrapper from "@components/NavigationWrapper.astro";
 import Heading from "@components/Heading.astro";
-import LatestPosts from "@components/LatestPosts.astro";
 import Featured from "@components/Featured.astro";
 import RecentProjects from "@components/RecentProjects.astro";
 import WorkExperiences from "@components/WorkExperiences.astro";
@@ -47,19 +46,8 @@ const pageTitle: string = "Where Code Meets Design";
       </div>
       <Featured />
     </section>
-    <section>
-      <div class="section-divider">
-        <div class="section-divider__title">
-          <span aria-hidden="true">📰</span>
-          <Heading
-            title="최신 글"
-            heading="3"
-          />
-        </div>
-        <div class="section-divider__line" aria-hidden="true"></div>
-        <a class="section-divider__link" href="/blog/">전체 글 보기</a>
-      </div>
-      <LatestPosts />
+    <section class="blog-link-section">
+      <a href="/blog/" class="blog-link">전체 글 보기 →</a>
     </section>
     <!-- <hr />
     <section>
@@ -148,6 +136,24 @@ const pageTitle: string = "Where Code Meets Design";
 
   .section-divider__link:hover,
   .section-divider__link:focus {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  .blog-link-section {
+    text-align: center;
+    margin-top: 2rem;
+  }
+
+  .blog-link {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-decoration: none;
+  }
+
+  .blog-link:hover,
+  .blog-link:focus {
     color: inherit;
     text-decoration: underline;
   }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -78,7 +78,7 @@ const sortedTagCloud = tagCloud
       </section>
     ) : null}
     <section>
-      <ul>
+      <ul class="post-list">
         {
           posts.map((post) => (
             <BlogPost


### PR DESCRIPTION
- Replace verbose post cards (description, tags, Korean date) with minimal single-line layout (title left, YYYY-MM-DD date right)
- Remove LatestPosts section from homepage, replace with blog link
- Add global .post-list class for consistent list style reset
- Apply post-list class across blog, featured, and tag pages